### PR TITLE
Fix git safe directory error on WSL2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,8 @@ RUN set -euo pipefail && \
     fi && \
     # clean up some junk
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* && \
+    # tell git to trust /src 
+    git config --global --add safe.directory /src && \
     # make super duper sure that everything went OK, exit otherwise
     hugo env && \
     go version && \


### PR DESCRIPTION
### Error Summary

Running `docker compose up` as a user with a different UID than the default user in the jakejarvis/hugo-docker container results in a git failure related to [safe directory checking](https://github.blog/2022-04-12-git-security-vulnerability-announced/).

```
user@hostname:~/projects/my-project$ docker compose up
[+] Running 1/0
 ⠿ Container my-project-hugo-1  Recreated                                                                           0.1s
Attaching to my-project-hugo-1
my-project-hugo-1  | hugo: downloading modules …
my-project-hugo-1  | hugo: collected modules in 14287 ms
my-project-hugo-1  | Start building sites …
my-project-hugo-1  | hugo v0.110.0-e32a493b7826d02763c3b79623952e625402b168+extended linux/amd64 BuildDate=2023-01-17T12:16:09Z VendorInfo=docker
my-project-hugo-1  | ERROR 2023/02/12 20:24:55 Failed to read Git log: fatal: detected dubious ownership in repository at '/src'
my-project-hugo-1  | To add an exception for this directory, call:
my-project-hugo-1  |
my-projecct-hugo-1  |     git config --global --add safe.directory /src
my-project-hugo-1  | Error: Error building site: logged 1 error(s)
my-project-hugo-1  | Built in 622 ms
my-project-hugo-1 exited with code 255
```

### Change Details

This pull request changes the container image build to set a global git configuration that treats /src as a trusted directory.  This occurs near the end of the build to reduce any potential security risk that might occur during the build itself.

### Testing

* Built hugo-docker from the HEAD of this pull request
* Ran `docker compose up` and validated that Hugo started and my site was served correctly

### Error Reproduction

This error was produced using WSL2 on Windows 11.

WSL version: 1.0.3.0
Kernel version: 5.15.79.1
WSLg version: 1.0.47
MSRDC version: 1.2.3575
Direct3D version: 1.606.4
DXCore version: 10.0.25131.1002-220531-1700.rs-onecore-base2-hyp
Windows version: 10.0.22621.1194
